### PR TITLE
Improve profile page speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-<p align="center"><img src="https://capsule-render.vercel.app/api?type=waving&color=0:239120,50:512BD4,100:0078D4&height=200&animation=twinkling&section=header&text=Gonzalo%20Maman%C3%AD%20L%C3%B3pez&fontSize=40&fontColor=FFFFFF"/>
-<img src="https://readme-typing-svg.demolab.com/?center=true&size=22&pause=1000&color=4DD0E1&vCenter=true&width=500&lines=Desarrollador+fullstack+en+.NET;Fundador+de+Dev+Jujuy"/></p>
-<p align="center"><img src="https://komarev.com/ghpvc/?username=MIKILO10&style=flat-square&color=brightgreen" alt="Profile views"/></p>
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:239120,50:512BD4,100:0078D4&height=200&animation=twinkling&section=header&text=Gonzalo%20Maman%C3%AD%20L%C3%B3pez&fontSize=40&fontColor=FFFFFF" loading="lazy"/>
+  <img src="https://readme-typing-svg.demolab.com/?center=true&size=22&pause=1000&color=4DD0E1&vCenter=true&width=500&lines=Desarrollador+fullstack+en+.NET;Fundador+de+Dev+Jujuy" loading="lazy"/>
+</p>
+<h1 align="center">¡Bienvenido a mi GitHub!</h1>
+<p align="center"><img src="https://komarev.com/ghpvc/?username=MIKILO10&style=flat-square&color=brightgreen" alt="Profile views" loading="lazy"/></p>
 
 
 ---
@@ -17,36 +20,40 @@
 
 ## 🧰 Stack actual
 
-![.NET](https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white)
-![C#](https://img.shields.io/badge/C%23-239120?style=flat&logo=csharp&logoColor=white)
-![SQL Server](https://img.shields.io/badge/SQL%20Server-CC2927?style=flat&logo=microsoftsqlserver&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white)
-![Azure](https://img.shields.io/badge/Azure-0078D4?style=flat&logo=microsoftazure&logoColor=white)
-![Vault](https://img.shields.io/badge/Vault-000000?style=flat&logo=HashiCorp&logoColor=white)
-![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=flat&logo=Jenkins&logoColor=white)
-![Angular](https://img.shields.io/badge/Angular-DD0031?style=flat&logo=angular&logoColor=white)
-![React](https://img.shields.io/badge/React-20232A?style=flat&logo=react&logoColor=61DAFB)
+<p align="center">
+  <img src="https://img.shields.io/badge/.NET-512BD4?style=flat&logo=dotnet&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/C%23-239120?style=flat&logo=csharp&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/SQL%20Server-CC2927?style=flat&logo=microsoftsqlserver&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/Azure-0078D4?style=flat&logo=microsoftazure&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/Vault-000000?style=flat&logo=HashiCorp&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/Jenkins-D24939?style=flat&logo=Jenkins&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/Angular-DD0031?style=flat&logo=angular&logoColor=white" loading="lazy" />
+  <img src="https://img.shields.io/badge/React-20232A?style=flat&logo=react&logoColor=61DAFB" loading="lazy" />
+</p>
 
 ## 🔢 Estadísticas rápidas
 
-![Seguidores](https://img.shields.io/github/followers/MIKILO10?style=flat-square&color=512BD4&label=Seguidores)
-![Stars](https://img.shields.io/github/stars/MIKILO10/MIKILO10?style=flat-square&color=F8D847&label=Stars)
-![Watchers](https://img.shields.io/github/watchers/MIKILO10/MIKILO10?style=flat-square&color=239120&label=Watchers)
+<p align="center">
+  <img src="https://img.shields.io/github/followers/MIKILO10?style=flat-square&color=512BD4&label=Seguidores" loading="lazy" />
+  <img src="https://img.shields.io/github/stars/MIKILO10/MIKILO10?style=flat-square&color=F8D847&label=Stars" loading="lazy" />
+  <img src="https://img.shields.io/github/watchers/MIKILO10/MIKILO10?style=flat-square&color=239120&label=Watchers" loading="lazy" />
+</p>
 
 ---
 
 ## 📈 GitHub Stats
 
 <p align="center">
-  <img src="https://github-profile-trophy.vercel.app/?username=MIKILO10&theme=radical&margin-w=15&no-frame=true" />
+  <img src="https://github-profile-trophy.vercel.app/?username=MIKILO10&theme=radical&margin-w=15&no-frame=true" loading="lazy" />
 </p>
 <p align="center">
-  <img src="https://github-readme-streak-stats.herokuapp.com/?user=MIKILO10&theme=radical" />
+  <img src="https://github-readme-streak-stats.herokuapp.com/?user=MIKILO10&theme=radical" loading="lazy" />
 </p>
 <p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=MIKILO10&show_icons=true&theme=radical&count_private=true&hide=issues" />
+  <img src="https://github-readme-stats.vercel.app/api?username=MIKILO10&show_icons=true&theme=radical&count_private=true&hide=issues" loading="lazy" />
   <br/>
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=MIKILO10&layout=compact&theme=radical&langs_count=6" />
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=MIKILO10&layout=compact&theme=radical&langs_count=6" loading="lazy" />
 </p>
 
 ## 🌟 Proyectos Destacados
@@ -57,9 +64,17 @@
 
 ## 📬 Contacto
 
-[![Email](https://img.shields.io/badge/Email-D14836?style=flat-square&logo=gmail&logoColor=white)](mailto:gonzalomamani.ucse10@gmail.com)
-[![Web](https://img.shields.io/badge/Web-239120?style=flat-square&logo=google-chrome&logoColor=white)](https://mikilo10.github.io/Portfolio/)
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/gjem10/)
+<p align="center">
+  <a href="mailto:gonzalomamani.ucse10@gmail.com">
+    <img src="https://img.shields.io/badge/Email-D14836?style=flat-square&logo=gmail&logoColor=white" alt="Email" loading="lazy" />
+  </a>
+  <a href="https://mikilo10.github.io/Portfolio/">
+    <img src="https://img.shields.io/badge/Web-239120?style=flat-square&logo=google-chrome&logoColor=white" alt="Web" loading="lazy" />
+  </a>
+  <a href="https://www.linkedin.com/in/gjem10/">
+    <img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white" alt="LinkedIn" loading="lazy" />
+  </a>
+</p>
 
 ---
 
@@ -70,5 +85,5 @@
 ---
 
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:239120,100:512BD4&height=100&section=footer"/>
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:239120,100:512BD4&height=100&section=footer" loading="lazy"/>
 </p>


### PR DESCRIPTION
## Summary
- use `loading="lazy"` on all images to reduce render blocking
- center skill, statistics, and contact badges for cleaner look
- add a short welcome heading for a more professional intro

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853ece7d1608332a965e83b518e1893