### PR TITLE
Refine color effects and remove black animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=239120,512BD4,0078D4&height=200&animation=twinkling&section=header&text=Gonzalo%20Maman%C3%AD%20L%C3%B3pez&fontSize=38&fontColor=FFFFFF" alt="Banner" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=239120,512BD4,0078D4&height=200&section=header&text=Gonzalo%20Maman%C3%AD%20L%C3%B3pez&fontSize=38&fontColor=FFFFFF" alt="Banner" />
   <img src="https://readme-typing-svg.demolab.com/?font=Fira+Code&pause=1000&center=true&vCenter=true&width=500&lines=Desarrollador+Fullstack+en+.NET;Fundador+de+Dev+Jujuy;Apasionado+por+el+c%C3%B3digo+y+la+automatizaci%C3%B3n" alt="Typing SVG" />
 </p>
 
-<h1 align="center"><font color="#FF5733">¡Bienvenido a mi GitHub!</font></h1>
-<p align="center"><font color="#0F9D58">Desarrollador fullstack especializado en .NET y entusiasta de la automatización.</font></p>
+<h1 align="center"><font color="#512BD4">¡Bienvenido a mi GitHub!</font></h1>
+<p align="center"><font color="#239120">Desarrollador fullstack especializado en .NET y entusiasta de la automatización.</font></p>
 <p align="center">
-  <img src="assets/animated.svg" alt="Animación de colores" width="60" />
+  <img src="assets/animated.svg" alt="Animación de gradiente" width="60" />
 </p>
 
 <p align="center">

--- a/assets/animated.svg
+++ b/assets/animated.svg
@@ -1,5 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60">
-  <circle cx="30" cy="30" r="20" fill="red">
-    <animate attributeName="fill" values="red;green;blue;red" dur="3s" repeatCount="indefinite" />
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#239120">
+        <animate attributeName="stop-color" values="#239120; #512BD4; #0078D4; #239120" dur="6s" repeatCount="indefinite" />
+      </stop>
+      <stop offset="100%" stop-color="#512BD4">
+        <animate attributeName="stop-color" values="#512BD4; #0078D4; #239120; #512BD4" dur="6s" repeatCount="indefinite" />
+      </stop>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="40" fill="url(#grad1)">
+    <animate attributeName="r" values="35;40;35" dur="3s" repeatCount="indefinite" />
   </circle>
 </svg>


### PR DESCRIPTION
## Summary
- drop dark twinkling animation from banner and align colors
- replace local SVG with gradient-based animation for a cleaner look
- adjust heading colors for a more professional palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f615d58c8332904a0810c8840c44